### PR TITLE
Fix bug with NaN hours on fixed price tasks

### DIFF
--- a/src/components/TaskRow/RowData.js
+++ b/src/components/TaskRow/RowData.js
@@ -21,6 +21,8 @@ const RowData = ({ description, hours, price, isEditing }) => (
     <span className={`${styles.cell} ${styles.hours}`}>
       {isEditing && hours.get !== '-' ? (
         <input type="number" defaultValue={hours.get} onChange={e => hours.set(e.target.value)} />
+      ) : hours.get === '-' ? (
+        '-'
       ) : (
         parseFloat(hours.get)
       )}


### PR DESCRIPTION
Fixes an issue where tasks with a fixed price would throw an error because we're trying to run `parseFloat()` on a string that just contains a dash.