### PR TITLE
Fix invoice edit bugs

### DIFF
--- a/src/components/active-invoice/index.tsx
+++ b/src/components/active-invoice/index.tsx
@@ -71,7 +71,14 @@ export default function ActiveInvoice({ invoice }: { invoice: Invoice }) {
           {invoiceCost(invoice.tasks)}
         </p>
         {client && user?.email === 'nick.braica@gmail.com' && (
-          <Button onClick={() => {}} style="inline" icon={IconDownload}>
+          <Button
+            onClick={() => {}}
+            style="inline"
+            icon={IconDownload}
+            key={invoice.tasks
+              .map((task) => task.description.replace(' ', ''))
+              .join('')}
+          >
             <PDFDownloadLink
               document={<InvoicePdf invoice={invoice} client={client} />}
               fileName={`invoice-${invoice.number.toLowerCase()}-${dateFormatterFilename(invoice.issueDate)}.pdf`}

--- a/src/components/edit-invoice-form/index.tsx
+++ b/src/components/edit-invoice-form/index.tsx
@@ -65,6 +65,7 @@ export default function EditInvoiceForm({
     try {
       const newData: Invoice = {
         ...invoice,
+        number: invoiceNumber,
         issueDate,
         dueDate,
         description,


### PR DESCRIPTION
Fixes two bugs with invoice editing:

- Ensures that an edit to the invoice number is saved.
- Forces a re-render of the PDF download link whenever the description for any invoice task gets updated (see https://github.com/diegomura/react-pdf/issues/2978).